### PR TITLE
add: openshift example values

### DIFF
--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -5,8 +5,18 @@ app:
     enabled: false
   containerSecurityContext:
     enabled: false
-  # ingress:
-  #   enabled: true
+  # see https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#architecture-routes-support-for-ingress
+  # cli ex: `oc expose svc labelstudio-ls-app` 
+  ingress:
+    enabled: true
+    annotations:
+      # note: the annotation below will allow a route to be created using a default wildcard certificate
+      route.openshift.io/termination: edge
+    # note: you will need to modify 'host' to your cluster domain
+    host: labelstudio-sandbox.apps.example.com
+    # note: below will also allow a route to be created using a default wildcard certificate
+    # tls:
+    #   - secretName: null
   rbac:
     create: true
 

--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -27,11 +27,3 @@ postgresql:
       enabled: false
     containerSecurityContext:
       enabled: false
-
-redis:
-  enabled: true
-  master:
-    podSecurityContext:
-      enabled: false
-    containerSecurityContext:
-      enabled: false

--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -1,4 +1,4 @@
-# Label Studio running on OpenShift
+# Example values for running Label Studio on OpenShift
 
 app:
   podSecurityContext:

--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -1,0 +1,31 @@
+# Label Studio running on OpenShift
+
+app:
+  podSecurityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
+  # ingress:
+  #   enabled: true
+
+rqworker:
+  podSecurityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
+
+postgresql:
+  enabled: true
+  primary:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
+
+redis:
+  enabled: true
+  master:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false

--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -7,12 +7,8 @@ app:
     enabled: false
   # ingress:
   #   enabled: true
-
-rqworker:
-  podSecurityContext:
-    enabled: false
-  containerSecurityContext:
-    enabled: false
+  rbac:
+    create: true
 
 postgresql:
   enabled: true
@@ -29,3 +25,12 @@ redis:
       enabled: false
     containerSecurityContext:
       enabled: false
+
+# Can enable the following when using Label Studio Enterprise
+
+# rqworker:
+#   podSecurityContext:
+#     enabled: false
+#   containerSecurityContext:
+#     enabled: false
+#   rbac: true

--- a/heartex/label-studio/example-values/label-studio-on-openshift.yaml
+++ b/heartex/label-studio/example-values/label-studio-on-openshift.yaml
@@ -35,12 +35,3 @@ redis:
       enabled: false
     containerSecurityContext:
       enabled: false
-
-# Can enable the following when using Label Studio Enterprise
-
-# rqworker:
-#   podSecurityContext:
-#     enabled: false
-#   containerSecurityContext:
-#     enabled: false
-#   rbac: true


### PR DESCRIPTION
### Description of the change

Add chart values to examples for deployment on OpenShift

### Benefits

The ability to deploy label studio on OpenShift easily with `helm`

### Possible drawbacks

Unknown

### Applicable issues

NA

### Additional information

OpenShift routes are a simplified ingress configuration - chart does not need modification at this time

### Checklist

N/A - adding example values, not changing chart

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

<!--
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Input Validation completed with `values.schema.json`.
- [ ] Variables are documented in the values.yaml and added to the `README.md`.
- [ ] Changelog updated to describe new changes/fixes.
- [ ] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
-->