### PR TITLE
Update helm release NOTES.txt to give correct url to the app for when…

### DIFF
--- a/heartex/label-studio/templates/NOTES.txt
+++ b/heartex/label-studio/templates/NOTES.txt
@@ -8,7 +8,7 @@ LABEL_STUDIO_HOST={{ .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST }}
 Get the application URL by running these commands:
 {{- if .Values.app.ingress.enabled }}
 {{- if not (hasKey .Values.global.extraEnvironmentVars "LABEL_STUDIO_HOST") }}
-Please visit http{{ if $.Values.app.ingress.tls }}s{{ end }}://{{ .Values.app.ingress.host }}{{ default "" .Values.app.ingress.path }} to use Label Studio
+Please visit http{{ if $.Values.app.ingress.tls }}s{{ end }}://{{ .Values.app.ingress.host }}{{ default "" .Values.app.contextPath }} to use Label Studio
 {{- else }}
 Please visit {{ .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST }} to use Label Studio
 {{- end }}


### PR DESCRIPTION
… ingress is enabled

Check out the line at the very beginning of the NOTES.txt and also https://github.com/HumanSignal/charts/blob/d7875d601d049d9170316b5e04a421ed36d257c8/heartex/label-studio/templates/_helpers.tpl#L311 