### PR TITLE
[heartex/label-studio] Allow deployment annotations to be added.

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * 
 
+## 1.4.9
+### Improvements
+* Add support for deployment annotations using .Values.app.deploymentAnnotations
+
 ### Fixes
 ## 1.4.7
 ### Fixes

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.4.8
+version: 1.4.9
 # Label Studio release version
 appVersion: "1.12.1"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/README.md
+++ b/heartex/label-studio/README.md
@@ -231,6 +231,7 @@ directory.
 |------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------|
 | `app.args`                                     | Override default container args (useful when using custom images)                                                    | `["label-studio-uwsgi"]` |
 | `app.deploymentStrategy.type`                  | Deployment strategy type                                                                                             | `RollingUpdate`          |
+| `app.deploymentAnnotations`                    | Deployment annotations                                                                                               | `{}`                     |
 | `app.replicas`                                 | Amount of app pod replicas                                                                                           | `1`                      |
 | `app.NameOverride`                             | String to partially override release template name                                                                   | `""`                     |
 | `app.FullnameOverride`                         | String to fully override release template name                                                                       | `""`                     |

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ls-app.fullname" . }}
+  {{- with .Values.app.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ls-app.labels" . | nindent 4 }}
     {{- if .Values.app.labels }}

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -346,6 +346,10 @@
           },
           "additionalProperties": true
         },
+        "deploymentAnnotations": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "replicas": {
           "type": "integer"
         },

--- a/heartex/label-studio/values.yaml
+++ b/heartex/label-studio/values.yaml
@@ -130,6 +130,8 @@ app:
   deploymentStrategy:
     type: RollingUpdate
 
+  deploymentAnnotations: { }
+  
   replicas: 1
 
   NameOverride: ""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

Allows the addition of annotations for the deployment in Kubernetes.

### Benefits

Where annotations are required at the deployment level this change introduces the ability to include them.

### Possible drawbacks

None known.

### Applicable issues

N/a
- fixes #

### Additional information

N/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Input Validation completed with `values.schema.json`.
- [X] Variables are documented in the values.yaml and added to the `README.md`.
- [X] Changelog updated to describe new changes/fixes.
- [X] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
