### PR TITLE
heartex/label-studio: allow specifying unknown global variables

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Improvements
 * Upgrade psql helm chart.
 * Pin psql version to 13.15.0.
+* Allow defining more global variables
 
 ## 1.5.0
 ### Improvements
@@ -27,7 +28,7 @@
 
 ## 1.4.5
 ### Improvements
-* Expose LS app service name and service port as an env variables. 
+* Expose LS app service name and service port as an env variables.
 
 ## 1.4.3
 ### Fixes

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.6.3
+version: 1.6.4
 # Label Studio release version
 appVersion: "1.13.1"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -286,7 +286,7 @@
           "additionalProperties": true
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "upgradeCheck": {
       "type": "object",


### PR DESCRIPTION
### Description of the change

This change allows specifying unknown global Variables when using this chart together with other charts (as dependencies) .

### Benefits

This is necessary when other charts rely on global variables, which would not work together with this chart.

### Possible drawbacks

This should not have any drawbacks whatsoever, since these new global variables are not used in the rendering of this helm chart

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Changelog updated to describe new changes/fixes.
- [X] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
