### PR TITLE
heartex/label-studio: explicitly set dnsPolicy, shareProcessNamespace and enableServiceLinks

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.0
+### Improvements
+* Explicitly set dnsPolicy, shareProcessNamespace and enableServiceLinks.
+* Set shareProcessNamespace and enableServiceLinks to `false`. 
+
 ## 1.6.0
 ### Improvements
 * Upgrade psql helm chart.

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.6.4
+version: 1.7.0
 # Label Studio release version
 appVersion: "1.13.1"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -308,15 +308,9 @@ spec:
       {{- if .Values.app.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "tplvalues.render" (dict "value" .Values.app.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.app.dnsPolicy }}
       dnsPolicy: {{ .Values.app.dnsPolicy }}
-      {{- end }}
-      {{- if .Values.app.enableServiceLinks }}
       enableServiceLinks: {{ .Values.app.enableServiceLinks }}
-      {{- end }}
-      {{- if .Values.app.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.app.shareProcessNamespace }}
-      {{- end }}
       {{- with .Values.app.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/heartex/label-studio/templates/cronjob.yaml
+++ b/heartex/label-studio/templates/cronjob.yaml
@@ -104,15 +104,9 @@ spec:
           {{- if $.Values.app.topologySpreadConstraints }}
           topologySpreadConstraints: {{- include "tplvalues.render" (dict "value" $.Values.app.topologySpreadConstraints "context" $) | nindent 8 }}
           {{- end }}
-          {{- if $.Values.app.dnsPolicy }}
           dnsPolicy: {{ $.Values.app.dnsPolicy }}
-          {{- end }}
-          {{- if $.Values.app.enableServiceLinks }}
           enableServiceLinks: {{ $.Values.app.enableServiceLinks }}
-          {{- end }}
-          {{- if $.Values.app.shareProcessNamespace }}
           shareProcessNamespace: {{ $.Values.app.shareProcessNamespace }}
-          {{- end }}
           {{- with $.Values.app.affinity }}
           affinity:
             {{- toYaml . | nindent 8 }}

--- a/heartex/label-studio/templates/rqworker-deployment.yaml
+++ b/heartex/label-studio/templates/rqworker-deployment.yaml
@@ -144,15 +144,9 @@ spec:
       {{- if $.Values.rqworker.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "tplvalues.render" (dict "value" $.Values.rqworker.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
-      {{- if $.Values.rqworker.dnsPolicy }}
       dnsPolicy: {{ $.Values.rqworker.dnsPolicy }}
-      {{- end }}
-      {{- if $.Values.rqworker.enableServiceLinks }}
       enableServiceLinks: {{ $.Values.rqworker.enableServiceLinks }}
-      {{- end }}
-      {{- if $.Values.rqworker.shareProcessNamespace }}
       shareProcessNamespace: {{ $.Values.rqworker.shareProcessNamespace }}
-      {{- end }}
       {{- with $.Values.rqworker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/heartex/label-studio/templates/upgrade-check-hook.yaml
+++ b/heartex/label-studio/templates/upgrade-check-hook.yaml
@@ -71,15 +71,9 @@ spec:
       {{- if .Values.app.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "tplvalues.render" (dict "value" .Values.app.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.app.dnsPolicy }}
       dnsPolicy: {{ .Values.app.dnsPolicy }}
-      {{- end }}
-      {{- if .Values.app.enableServiceLinks }}
       enableServiceLinks: {{ .Values.app.enableServiceLinks }}
-      {{- end }}
-      {{- if .Values.app.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.app.shareProcessNamespace }}
-      {{- end }}
       {{- with .Values.app.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Description of the change

This PR improves the Helm chart configuration by explicitly setting the following fields in the deployment manifest:

- `dnsPolicy`: Defined according to .Values.app.dnsPolicy.
- `enableServiceLinks`: Set to false, unless specified otherwise.
- `shareProcessNamespace`: Set to false, unless specified otherwise.
These settings ensure better control over the application's DNS policy, process namespace sharing, and service link enablement, leading to a more consistent and predictable configuration.

### Benefits

Setting shareProcessNamespace and enableServiceLinks to false reduces potential security risks by limiting inter-process communication and preventing unnecessary service link creation.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
