### PR TITLE
heartex/label-studio Fix livenessProbe and readinessProbe paths for nginx

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.3
+### Improvements
+* Fix the path in readinessProbe and livenessProbe for the nginx container to use app.contextPath
+
 ## 1.7.0
 ### Improvements
 * Explicitly set dnsPolicy, shareProcessNamespace and enableServiceLinks.

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.7.2
+version: 1.7.3
 # Label Studio release version
 appVersion: "1.14.0.post0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -232,7 +232,7 @@ spec:
           {{- if .Values.app.nginx.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.readinessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.readinessProbe.path }}{{ end }}"
+              path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.nginx.readinessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.nginx.readinessProbe.path }}{{ end }}"
               port: 8085
             failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
@@ -243,7 +243,7 @@ spec:
           {{- if .Values.app.nginx.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: "{{ .Values.app.nginx.livenessProbe.path }}"
+              path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.nginx.livenessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.nginx.livenessProbe.path }}{{ end }}"
               port: 8085
             failureThreshold: {{ .Values.app.nginx.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.app.nginx.livenessProbe.initialDelaySeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

Fix livenessProbe path for nginx to make use of the app.contextPath value
Fix readinessProbe path for nginx to make use of the nginx own values and not from the app

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
