### PR TITLE
[heartex/label-studio] Add missing readiness probe for app deployment & fix nginx readinessProbe reference

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 1.9.5
+### Fixes
+* Add missing readiness probe for app deployment app container.
+* Fix nginx container readiness probe reference in app deployment.
+
 ## 1.9.3
 ### Improvements
 * Support to omit secrets in downstream values.
@@ -28,7 +33,7 @@
 ## 1.7.0
 ### Improvements
 * Explicitly set dnsPolicy, shareProcessNamespace and enableServiceLinks.
-* Set shareProcessNamespace and enableServiceLinks to `false`. 
+* Set shareProcessNamespace and enableServiceLinks to `false`.
 
 ## 1.6.0
 ### Improvements

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.9.4
+version: 1.9.5
 # Label Studio release version
 appVersion: "1.16.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -146,6 +146,17 @@ spec:
             - name: CMD_WRAPPER
               value: {{ coalesce $.Values.app.cmdWrapper $.Values.global.cmdWrapper }}
             {{- end }}
+          {{- if .Values.app.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.readinessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.readinessProbe.path }}{{ end }}"
+              port: 8000
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.app.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -234,11 +245,11 @@ spec:
             httpGet:
               path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.nginx.readinessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.nginx.readinessProbe.path }}{{ end }}"
               port: 8085
-            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
-            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
-            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.nginx.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.app.nginx.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.nginx.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.nginx.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.nginx.readinessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.app.nginx.livenessProbe.enabled }}
           livenessProbe:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change adds a readiness probe for the app container to ensure proper startup and health monitoring & fixes the nginx reference.

### Benefits

<!-- What benefits will be realized by the code change? -->

- Improved container health monitoring
- Better orchestration of pod startup
- More reliable deployments

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None identified - this is a standard Kubernetes best practice.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Input Validation completed with `values.schema.json`.
- [X] Variables are documented in the values.yaml and added to the `README.md`.
- [X] Changelog updated to describe new changes/fixes.
- [X] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
