### PR TITLE
[heartex/label-studio] Add scheme to probes and sidecar container support

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 1.9.6
+### Fixes
+* Add `scheme` field to readinessProbe and livenessProbe for nginx container.
+* Add configuration for additional sidecar containers to run alongside the app's USWGI and nginx containers.
+
 ## 1.9.5
 ### Fixes
 * Add missing readiness probe for app deployment app container.

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.9.5
+version: 1.9.6
 # Label Studio release version
 appVersion: "1.16.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/README.md
+++ b/heartex/label-studio/README.md
@@ -300,6 +300,7 @@ directory.
 | `app.nginx.livenessProbe.periodSeconds`        | Nginx sidecar container: How often (in seconds) to perform the probe                                                                                   | `5`                      |
 | `app.nginx.livenessProbe.successThreshold`     | Nginx sidecar container: Minimum consecutive successes for the probe to be considered successful after having failed                                   | `1`                      |
 | `app.nginx.livenessProbe.timeoutSeconds`       | Nginx sidecar container: Number of seconds after which the probe times out                                                                             | `3`                      |
+| `app.nginx.livenessProbe.scheme`               | Nginx sidecar container: Scheme for livenessProbe                                                                                                       | `HTTP`                   |
 | `app.nginx.readinessProbe.enabled`             | Nginx sidecar container: Enable redinessProbe                                                                                                          | `true`                   |
 | `app.nginx.readinessProbe.path`                | Nginx sidecar container: Path for reasinessProbe                                                                                                       | `/version`               |
 | `app.nginx.readinessProbe.failureThreshold`    | Nginx sidecar container: When a probe fails, Kubernetes will try failureThreshold times before giving up                                               | `2`                      |
@@ -307,6 +308,7 @@ directory.
 | `app.nginx.readinessProbe.periodSeconds`       | Nginx sidecar container: How often (in seconds) to perform the probe                                                                                   | `10`                     |
 | `app.nginx.readinessProbe.successThreshold`    | Nginx sidecar container: Minimum consecutive successes for the probe to be considered successful after having failed                                   | `1`                      |
 | `app.nginx.readinessProbe.timeoutSeconds`      | Nginx sidecar container: Number of seconds after which the probe times out                                                                             | `5`                      |
+| `app.nginx.readinessProbe.scheme`              | Nginx sidecar container: Scheme for readinessProbe                                                                                                      | `HTTP`                   |
 | `app.service.type`                             | k8s service type                                                                                                                                       | `ClusterIP`              |
 | `app.service.port`                             | k8s service port                                                                                                                                       | `80`                     |
 | `app.service.targetPort`                       | k8s service target port                                                                                                                                | `8085`                   |
@@ -331,6 +333,7 @@ directory.
 | `app.pdb.create`                               | Enable/disable a Pod Disruption Budget creation                                                                                                        | `true`                   |
 | `app.pdb.minAvailable`                         | Minimum number/percentage of pods that should remain scheduled                                                                                         | `""`                     |
 | `app.pdb.maxUnavailable`                       | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `app.pdb.minAvailable` and `app.pdb.maxUnavailable` are empty. | `""`                     |
+| `app.sidecarContainers`                        | Additional sidecar containers to the App Deployment pod                                                                                                | `[]`                     |
 
 ### Rqworker parameters
 

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -245,6 +245,7 @@ spec:
             httpGet:
               path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.nginx.readinessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.nginx.readinessProbe.path }}{{ end }}"
               port: 8085
+              scheme: {{ .Values.app.nginx.readinessProbe.scheme | default "HTTP" }}
             failureThreshold: {{ .Values.app.nginx.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.app.nginx.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.nginx.readinessProbe.periodSeconds }}
@@ -256,6 +257,7 @@ spec:
             httpGet:
               path: "{{ if eq .Values.app.contextPath "/" }}{{ .Values.app.nginx.livenessProbe.path }}{{ else }}{{ .Values.app.contextPath }}{{ .Values.app.nginx.livenessProbe.path }}{{ end }}"
               port: 8085
+              scheme: {{ .Values.app.nginx.livenessProbe.scheme | default "HTTP" }}
             failureThreshold: {{ .Values.app.nginx.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.app.nginx.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.nginx.livenessProbe.periodSeconds }}
@@ -312,6 +314,45 @@ spec:
             - name: "uwsgimetrics"
               containerPort: 9117
           {{- end }}
+        {{- if .Values.app.sidecarContainers }}
+        {{- range .Values.app.sidecarContainers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
+          {{- if .securityContext }}
+          securityContext: {{ toYaml .securityContext | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ls.common.envs" $ | nindent 12 }}
+            {{- if .extraEnvironmentVars -}}
+            {{- range $key, $value := .extraEnvironmentVars }}
+            - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .extraEnvironmentSecrets -}}
+            {{- range $key, $value := .extraEnvironmentSecrets }}
+            - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $value.secretName }}
+                  key: {{ $value.secretKey }}
+            {{- end }}
+            {{- end }}
+          {{- if .readinessProbe }}
+          readinessProbe: {{ toYaml .readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .livenessProbe }}
+          livenessProbe: {{ toYaml .livenessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          volumeMounts:
+            {{- if .volumeMounts }}
+              {{ toYaml .volumeMounts | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.app.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -459,6 +459,9 @@
                 },
                 "timeoutSeconds": {
                   "type": "integer"
+                },
+                "scheme": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -486,6 +489,9 @@
                 },
                 "timeoutSeconds": {
                   "type": "integer"
+                },
+                "scheme": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -748,6 +754,52 @@
             }
           },
           "additionalProperties": false
+        },
+        "sidecarContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "securityContext": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "extraEnvironmentVars": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "extraEnvironmentSecrets": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "readinessProbe": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "livenessProbe": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "resources": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "volumeMounts": {
+                "type": "array",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/heartex/label-studio/values.yaml
+++ b/heartex/label-studio/values.yaml
@@ -103,9 +103,7 @@ global:
 
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: "newrelic-admin run-program"
-  ##
-  cmdWrapper: ""
+  ## cmdWrapper: ""
 
   # File names of a custom SSL root certs. These filename will be appended to existing root certs.
   # "- /tmp/my_cool_root_cert"
@@ -176,6 +174,7 @@ app:
       periodSeconds: 5
       successThreshold: 1
       timeoutSeconds: 3
+      scheme: "HTTP"
     readinessProbe:
       enabled: true
       path: "/version"
@@ -184,6 +183,7 @@ app:
       periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
+      scheme: "HTTP"
 
   # extraEnvironmentVars is a list of extra environment variables to set in the
   # app deployment.
@@ -357,9 +357,7 @@ app:
   contextPath: /
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: "newrelic-admin run-program"
-  ##
-  cmdWrapper: ""
+  ## cmdWrapper: ""
 
   ## Minimal number of seconds preStop hook waits before LS is stopped to finish processing requests
   ## Note: must be set to lower value than terminationGracePeriodSeconds so that preStop hook finishes
@@ -389,6 +387,17 @@ app:
     create: false
     minAvailable: ""
     maxUnavailable: ""
+
+  ## Add additional sidecar containers to the App Deployment pod
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/#sidecar-containers
+  ## e.g:
+  ## sidecarContainers:
+  ##  - name: your-sidecar-name
+  ##    image: your-sidecar-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  sidecarContainers: [ ]
 
 rqworker:
   enabled: true
@@ -525,7 +534,7 @@ rqworker:
     name: ""
     # Extra k8s annotations for the serviceAccount definition. This can either be
     # YAML or a YAML-formatted multi-line templated string map of the
-    # annotations to apply to the serviceAccount.
+    # k8s annotations to apply to the serviceAccount.
     annotations: { }
 
   # Array to add extra volumes
@@ -572,9 +581,7 @@ rqworker:
 
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: "newrelic-admin run-python"
-  ##
-  cmdWrapper: ""
+  ## cmdWrapper: ""
 
   # Seconds rqworker pod needs to terminate gracefully
   terminationGracePeriodSeconds: 30

--- a/heartex/label-studio/values.yaml
+++ b/heartex/label-studio/values.yaml
@@ -486,7 +486,7 @@ rqworker:
 
   # Extra k8s annotations to attach to the rqworker pods
   # This can either be YAML or a YAML-formatted multi-line templated string map
-  # of the k8s annotations to apply to the rqworker pods
+  # of the annotations to apply to the rqworker pods
   annotations: { }
 
   # Extra k8s labels to attach to the rqworker

--- a/heartex/label-studio/values.yaml
+++ b/heartex/label-studio/values.yaml
@@ -103,7 +103,9 @@ global:
 
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: ""
+  ## cmdWrapper: "newrelic-admin run-program"
+  ##
+  cmdWrapper: ""
 
   # File names of a custom SSL root certs. These filename will be appended to existing root certs.
   # "- /tmp/my_cool_root_cert"
@@ -357,7 +359,9 @@ app:
   contextPath: /
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: ""
+  ## cmdWrapper: "newrelic-admin run-program"
+  ##
+  cmdWrapper: ""
 
   ## Minimal number of seconds preStop hook waits before LS is stopped to finish processing requests
   ## Note: must be set to lower value than terminationGracePeriodSeconds so that preStop hook finishes
@@ -581,7 +585,9 @@ rqworker:
 
   ## @param app.cmdWrapper Additional commands to run prior to starting App. Useful to run wrappers before startup command
   ## e.g:
-  ## cmdWrapper: ""
+  ## cmdWrapper: "newrelic-admin run-program"
+  ##
+  cmdWrapper: ""
 
   # Seconds rqworker pod needs to terminate gracefully
   terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Update Helm Chart to allow specifying the scheme for readiness and liveness probes for `nginx` (e.g. when using HTTPS / TLS with certificates and termination at `nginx` and not ingress level) and to specify additional sidecar containers (e.g. sidecar container to access a PostgreSQL database using an IAM sidecar).

* **heartex/label-studio/templates/app-deployment.yaml**
  - Add `scheme` field to readinessProbe and livenessProbe for nginx container.
  - Add configuration for additional sidecar containers to run alongside the app's USWGI and nginx containers.

* **heartex/label-studio/values.yaml**
  - Add configuration for `nginx.readinessProbe.scheme` and `nginx.livenessProbe.scheme`.
  - Add configuration for additional sidecar containers.

* **heartex/label-studio/values.schema.json**
  - Add schema validation for `nginx.readinessProbe.scheme` and `nginx.livenessProbe.scheme`.
  - Add schema validation for additional sidecar containers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/benglewis/label-studio-charts/pull/1?shareId=b04c1309-8c9a-4280-9b73-5fa8eb8a30df).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
