### PR TITLE
[heartex/label-studio] Add `args` to `sidecarContainers`

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.11
+- Added `args` to `sidecarContainers`.
+
 ## 1.9.9
 - Upgraded Label Studio application version to 1.17.0
 

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.9.10
+version: 1.9.11
 # Label Studio release version
 appVersion: "1.18.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -323,6 +323,9 @@ spec:
         - name: {{ .name }}
           image: {{ .image }}
           imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
+          {{- if .args }}
+          args: {{ .args }}
+          {{- end }}
           {{- if .securityContext }}
           securityContext: {{ toYaml .securityContext | nindent 12 }}
           {{- end }}

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -769,6 +769,10 @@
               "imagePullPolicy": {
                 "type": "string"
               },
+              "args": {
+                "type": "object",
+                "additionalProperties": true
+              },
               "securityContext": {
                 "type": "object",
                 "additionalProperties": true


### PR DESCRIPTION
### Description of the change

Add optional `args` field to `sidecarContainers` items.

### Benefits

It allows greater customizability of the containers run as sidecar containers.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
