### PR TITLE
[heartex/label-studio] Sidecar containers args fixes

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.12
+- Fixed `args` support in `sidecarContainers`.
+
 ## 1.9.11
 - Added `args` to `sidecarContainers`.
 

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.9.11
+version: 1.9.12
 # Label Studio release version
 appVersion: "1.18.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -324,7 +324,9 @@ spec:
           image: {{ .image }}
           imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
           {{- if .args }}
-          args: {{ .args }}
+          args: {{- range .args }}
+            - {{ . }}
+          {{- end }}
           {{- end }}
           {{- if .securityContext }}
           securityContext: {{ toYaml .securityContext | nindent 12 }}

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -770,7 +770,7 @@
                 "type": "string"
               },
               "args": {
-                "type": "object",
+                "type": "array",
                 "additionalProperties": true
               },
               "securityContext": {


### PR DESCRIPTION
### Description of the change

In my last PR, I realize now that I was a little hasty and did not implement the `args` support in the `sidecarContainers` correctly. This PR fixes the bugs there.

### Benefits

Users of `sideContainers` like myself.

### Possible drawbacks

N/A

### Applicable issues

N/A.

I didn't open an issue ticket yet, but essentially this is the error that made me realize my mistake:
```
values don't meet the specifications of the schema(s) in the following chart(s):
    label-studio:
    - app.sidecarContainers.0.args: Invalid type. Expected: object, given: array
```

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
