### PR TITLE
[heartex/label-studio] Native sidecar containers

### DIFF
--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.12
+- Added support for native sidecar containers (`initContainers` with `restartPolicy` of `Always`).
+
 ## 1.9.11
 - Added `args` to `sidecarContainers`.
 

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.9.11
+version: 1.9.12
 # Label Studio release version
 appVersion: "1.18.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -85,6 +85,7 @@ spec:
             - {{ . }}
           {{- end }}
           imagePullPolicy: {{ or .pullPolicy $.Values.global.image.pullPolicy }}
+          restartPolicy: {{ or .restartPolicy "OnFailure" }}
           {{- if $.Values.app.containerSecurityContext.enabled }}
           securityContext: {{- omit $.Values.app.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/heartex/label-studio/templates/app-deployment.yaml
+++ b/heartex/label-studio/templates/app-deployment.yaml
@@ -42,41 +42,6 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.app.automountServiceAccountToken }}
       initContainers:
-        - name: db-migrations
-          image: "{{ .Values.global.image.registry | default "docker.io" }}/{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}"
-          args: [ "label-studio-migrate" ]
-          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- if .Values.app.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.app.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
-          resources:
-            {{- toYaml .Values.app.initContainer.resources | nindent 12 }}
-          env:
-            {{- include "ls.common.envs" . | nindent 12 }}
-            - name: INIT_CONTAINER
-              value: "true"
-            {{- if .Values.app.debug }}
-            - name: DEBUG
-              value: "true"
-            {{- end }}
-          volumeMounts:
-            - name: data
-              mountPath: /label-studio/data
-            - mountPath: /opt/heartex/instance-data/etc
-              name: opt-heartex-init
-            - mountPath: /tmp
-              name: tmp-dir-init
-            {{- if .Values.global.pgConfig.ssl.pgSslSecretName }}
-            - name: pg-ssl-certs
-              mountPath: /opt/heartex/secrets/pg_certs
-            {{- end }}
-            {{- if .Values.global.redisConfig.ssl.redisSslSecretName }}
-            - name: redis-ssl-certs
-              mountPath: /opt/heartex/secrets/redis_certs
-            {{- end }}
-            {{- if .Values.app.extraVolumeMounts }}
-              {{ toYaml .Values.app.extraVolumeMounts | nindent 12 }}
-            {{- end }}
         {{- if .Values.app.initContainers }}
         {{- range .Values.app.initContainers }}
         - name: {{ .name }}
@@ -117,6 +82,41 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
+        - name: db-migrations
+          image: "{{ .Values.global.image.registry | default "docker.io" }}/{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}"
+          args: [ "label-studio-migrate" ]
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- if .Values.app.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.app.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.app.initContainer.resources | nindent 12 }}
+          env:
+            {{- include "ls.common.envs" . | nindent 12 }}
+            - name: INIT_CONTAINER
+              value: "true"
+            {{- if .Values.app.debug }}
+            - name: DEBUG
+              value: "true"
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /label-studio/data
+            - mountPath: /opt/heartex/instance-data/etc
+              name: opt-heartex-init
+            - mountPath: /tmp
+              name: tmp-dir-init
+            {{- if .Values.global.pgConfig.ssl.pgSslSecretName }}
+            - name: pg-ssl-certs
+              mountPath: /opt/heartex/secrets/pg_certs
+            {{- end }}
+            {{- if .Values.global.redisConfig.ssl.redisSslSecretName }}
+            - name: redis-ssl-certs
+              mountPath: /opt/heartex/secrets/redis_certs
+            {{- end }}
+            {{- if .Values.app.extraVolumeMounts }}
+              {{ toYaml .Values.app.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.app.terminationGracePeriodSeconds }}
       containers:
         - name: app


### PR DESCRIPTION
### Description of the change

Add support for native Kubernetes sidecar containers.

### Benefits

Native Kubernetes sidecar containers can be used alongside `initContainers` allowing for usage of sidecar containers to access the database / collect logs / networking during the init container phase.

### Possible drawbacks

The `initContainers` entry from the `values` was moved to before the default `initContainers`.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Changelog updated to describe new changes/fixes.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
